### PR TITLE
ADD kd87a_bfg_edition

### DIFF
--- a/v3/darkproject/kd87a_bfg_edition/kd87a_bfg_edition.json
+++ b/v3/darkproject/kd87a_bfg_edition/kd87a_bfg_edition.json
@@ -1,0 +1,220 @@
+{
+  "name": "kd87a_bfg_edition",
+  "vendorId": "0x342d",
+  "productId": "0xe393",
+  "lighting": {
+    "extends": "qmk_rgblight",
+    "underglowEffects": [
+      ["None", 0],
+      ["SOLID_COLOR", 1],
+      ["ALPHAS_MODS", 1],
+      ["GRADIENT_UP_DOWN", 1],
+      ["GRADIENT_LEFT_RIGHT", 1],
+      ["BREATHING", 1],
+      ["BAND_SAT", 1],
+      ["BAND_VAL", 1],
+      ["BAND_PINWHEEL_SAT", 1],
+      ["BAND_PINWHEEL_VAL", 1],
+      ["BAND_SPIRAL_SAT", 1],
+      ["BAND_SPIRAL_VAL", 1],
+      ["RAINBOW_BEACON", 1],
+      ["CYCLE_ALL", 1],
+      ["CYCLE_UP_DOWN", 1],
+      ["CYCLE_LEFT_RIGHT", 1],
+      ["CYCLE_OUT_IN", 1],
+      ["CYCLE_OUT_IN_DUAL", 1],
+      ["CYCLE_PINWHEEL", 1],
+      ["CYCLE_SPIRAL", 1],
+      ["DUAL_BEACON", 1],
+      ["RAINBOW_BEACON", 1],
+      ["RAINBOW_PINWHEELS", 1],
+      ["RAINDROPS", 1],
+      ["JELLYBEAN_RAINDROPS", 1],
+      ["HUE_BREATHING", 1]
+    ]
+  },
+  "matrix": {"rows": 14, "cols": 8},
+  "customKeycodes": [
+    {"name": "Mission Control", "title": "Mission Control in macOS", "shortName": "Mission Control"},
+    {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "Launch Pad"},
+    {"name": "Left Option", "title": "Left Option in macOS", "shortName": "Left Option"},
+    {"name": "Right Option", "title": "Right Option in macOS", "shortName": "Right Option"},
+    {"name": "Left Cmd", "title": "Left Command in macOS", "shortName": "Left Command"},
+    {"name": "Right Cmd", "title": "Right Command in macOS", "shortName": "Right Command"},
+    {"name": "Task View", "title": "Task View in windows", "shortName": "Task View"},
+    {"name": "File Explorer", "title": "File Explorer in windows", "shortName": "File Explorer"}
+  ],
+  "layouts": {
+        "keymap":[
+       [
+        "1,3\nESC",
+        {
+          "x": 1,
+          "c": "#cccccc"
+        },
+        "2,6",
+        "3,6",
+        "3,1",
+        "3,3",
+        {
+          "x":0.5
+        },
+        "0,7",
+        "6,3",
+        "7,1",
+        "7,6",
+        {
+          "x":0.5
+        },
+        "10,6",
+        "10,7",
+        "10,3",
+        "10,5",
+        {
+          "x":0.5
+        },
+        "9,7",
+        "10,0",
+        "9,6"
+      ],
+      [
+        "1,6",
+        "1,7",
+        "2,7",
+        "3,7",
+        "4,7",
+        "4,6",
+        "5,6",
+        "5,7",
+        "6,7",
+        "7,7",
+        "8,7",
+        "8,6",
+        "6,6",
+        {
+          "w": 2
+        },
+        "10,1",
+        {
+          "x":0.5
+        },
+        "12,6",
+        "0,2",
+        "1,5"
+      ],
+      [
+        {
+          "w": 1.5
+        },
+        "1,1",
+        "1,0",
+        "2,0",
+        "3,0",
+        "4,0",
+        "4,1",
+        "5,1",
+        "5,0",
+        "6,0",
+        "7,0",
+        "8,0",
+        "8,1",
+        "6,1",
+        {
+          "w": 1.5
+        },
+        "10,2",
+        {
+          "x":0.5
+        },  
+        "6,5",
+        "7,5",
+        "2,5"
+      ],
+      [
+        {
+          "w": 1.75
+        },
+        "2,1",
+        "1,2",
+        "2,2",
+        "3,2",
+        "4,2",
+        "4,3",
+        "5,3",
+        "5,2",
+        "6,2",
+        "7,2",
+        "8,2",
+        "8,3",
+        {
+          "w": 2.25
+        },
+        "10,4"
+      ],
+      [
+        {
+          "w": 2.25
+        },
+        "0,0",
+        "1,4",
+        "2,4",
+        "3,4",
+        "4,4",
+        "4,5",
+        "5,5",
+        "5,4",
+        "6,4",
+        "7,4",
+        "8,5",
+        {
+          "w": 2.75
+        },
+        "9,1",
+        {
+          "x":1.5
+        },
+        "3,5"
+      ],
+      [
+        {
+          "w": 1.25
+        },
+        "0,6",
+        {
+          "w": 1.25
+        },
+        "9,0",
+        {
+          "w": 1.25
+        },
+        "9,3",
+        {
+          "w": 6.25
+        },
+        "9,4",
+        {
+          "w": 1.25
+        },
+        "9,5",
+        {
+          "w": 1.25
+        },
+        "9,2",
+        {
+          "w": 1.25
+        },
+        "8,4",
+        {
+          "w": 1.25
+        },
+        "0,4",
+        {
+          "x":0.5
+        },
+        "0,3",
+        "7,3",
+        "0,5"
+      ]
+    ]
+  }
+}


### PR DESCRIPTION

## Description

ADD kd87a_bfg_edition keyboard

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist


- [ ] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
