### PR TITLE
Add keyboard to change matrix-Vortex/m0110_700

### DIFF
--- a/v3/vortex/ansi/m0110_700/m0110_700_ansi.json
+++ b/v3/vortex/ansi/m0110_700/m0110_700_ansi.json
@@ -3,7 +3,7 @@
   "vendorId": "0x342D",
   "productId": "0xE3A4",
 
-  "matrix": {"rows": 14, "cols": 8},
+  "matrix": {"rows": 11, "cols": 8},
   "layouts": {
         "keymap":[
       [


### PR DESCRIPTION

## Description

Change matrix from previous version to vortex/m0110_700_ansi

## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is **MERGED** in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have a V3 JSON version for this keyboard definition.**(MANDATORY)**
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [ ] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
